### PR TITLE
Update caller workflows for build and deploy automation

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -1,5 +1,8 @@
 ### This is the Terraform-generated dev-build.yml workflow for the wcd2reshare-dev app repository ###
-name: Dev Build and Deploy lambda Container
+### If this is a Lambda repo, uncomment the FUNCTION line at the end of the document     ###
+### If the container requires any additional pre-build commands, uncomment and edit      ###
+### the PREBUILD line at the end of the document.                                        ###
+name: Dev Container Build and Deploy
 on:
   workflow_dispatch:
   pull_request:
@@ -10,11 +13,12 @@ on:
 
 jobs:
   deploy:
-    name: Dev Deploy lambda Container
-    uses: mitlibraries/.github/.github/workflows/lambda-shared-deploy-dev.yml@main
+    name: Dev Container Deploy
+    uses: mitlibraries/.github/.github/workflows/ecr-shared-deploy-dev.yml@main
     secrets: inherit
     with:
       AWS_REGION: "us-east-1"
       GHA_ROLE: "wcd2reshare-gha-dev"
       ECR: "wcd2reshare-dev"
       FUNCTION: "wcd2reshare-dev"
+      # PREBUILD: 

--- a/.github/workflows/prod-promote.yml
+++ b/.github/workflows/prod-promote.yml
@@ -1,5 +1,6 @@
-### This is the Terraform-generated prod-promote.yml workflow for the wcd2reshare-prod app repository ###
-name: Prod Promote Lambda Container
+### This is the Terraform-generated prod-promote.yml workflow for the wcd2reshare-prod repository. ###
+### If this is a Lambda repo, uncomment the FUNCTION line at the end of the document.         ###
+name: Prod Container Promote
 on:
   workflow_dispatch:
   release:
@@ -7,8 +8,8 @@ on:
 
 jobs:
   deploy:
-    name: Prod Promote Lambda Container
-    uses: mitlibraries/.github/.github/workflows/lambda-shared-promote-prod.yml@main
+    name: Prod Container Promote
+    uses: mitlibraries/.github/.github/workflows/ecr-shared-promote-prod.yml@main
     secrets: inherit
     with:
       AWS_REGION: "us-east-1"

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -1,5 +1,8 @@
-### This is the Terraform-generated stage-build.yml workflow for the wcd2reshare-stage repository ###
-name: Stage Build and Deploy Lambda Container
+### This is the Terraform-generated dev-build.yml workflow for the wcd2reshare-stage app repository ###
+### If this is a Lambda repo, uncomment the FUNCTION line at the end of the document     ###
+### If the container requires any additional pre-build commands, uncomment and edit      ###
+### the PREBUILD line at the end of the document.                                        ###
+name: Stage Container Build and Deploy
 on:
   workflow_dispatch:
   push:
@@ -10,11 +13,12 @@ on:
 
 jobs:
   deploy:
-    name: Stage Deploy Lambda Container
-    uses: mitlibraries/.github/.github/workflows/lambda-shared-deploy-stage.yml@main
+    name: Stage Container Deploy
+    uses: mitlibraries/.github/.github/workflows/ecr-shared-deploy-stage.yml@main
     secrets: inherit
     with:
       AWS_REGION: "us-east-1"
       GHA_ROLE: "wcd2reshare-gha-stage"
       ECR: "wcd2reshare-stage"
       FUNCTION: "wcd2reshare-stage"
+      # PREBUILD: 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
-### This is the Terraform-generated header for wcd2reshare-dev ###
+### This is the Terraform-generated header for wcd2reshare-dev. If  ###
+###   this is a Lambda repo, uncomment the FUNCTION line below      ###
+###   and review the other commented lines in the document.         ###
 ECR_NAME_DEV:=wcd2reshare-dev
 ECR_URL_DEV:=222053980223.dkr.ecr.us-east-1.amazonaws.com/wcd2reshare-dev
 FUNCTION_DEV:=wcd2reshare-dev
-### End of Terraform-generated header ###
+### End of Terraform-generated header                               ###
 
 ### Dependency commands ###
 install: ## Install dependencies
@@ -51,14 +53,16 @@ publish-dev: dist-dev ## Build, tag and push (intended for developer-based manua
 	docker push $(ECR_URL_DEV):latest
 	docker push $(ECR_URL_DEV):`git describe --always`
 
+### If this is a Lambda repo, uncomment the two lines below     ###
 update-lambda-dev: ## Updates the lambda with whatever is the most recent image in the ecr (intended for developer-based manual update)
 	aws lambda update-function-code --function-name $(FUNCTION_DEV) --image-uri $(ECR_URL_DEV):latest
 
 
-### Terraform-generated manual shortcuts for deploying to Stage ###
-### This requires that ECR_NAME_STAGE, ECR_URL_STAGE, and FUNCTION_STAGE environment variables are
-### set locally by the developer and that the developer has authenticated to the correct AWS Account.
-### The values for the environment variables can be found in the stage_build.yml caller workflow.
+### Terraform-generated manual shortcuts for deploying to Stage. This requires  ###
+###   that ECR_NAME_STAGE, ECR_URL_STAGE, and FUNCTION_STAGE environment        ###
+###   variables are set locally by the developer and that the developer has     ###
+###   authenticated to the correct AWS Account. The values for the environment  ###
+###   variables can be found in the stage_build.yml caller workflow.            ###
 dist-stage: ## Only use in an emergency
 	docker build --platform linux/amd64 \
 	    -t $(ECR_URL_STAGE):latest \
@@ -70,5 +74,6 @@ publish-stage: ## Only use in an emergency
 	docker push $(ECR_URL_STAGE):latest
 	docker push $(ECR_URL_STAGE):`git describe --always`
 
+### If this is a Lambda repo, uncomment the two lines below     ###
 update-lambda-stage: ## Updates the lambda with whatever is the most recent image in the ecr (intended for developer-based manual update)
 	aws lambda update-function-code --function-name $(FUNCTION_STAGE) --image-uri $(ECR_URL_STAGE):latest


### PR DESCRIPTION
### What does this PR do?

* Update three caller workflows to use the new outputs from the mitlib-tf-workloads-ecr repository
* Update the comments in the Makefile with updates from the mitlib-tf-workloads-ecr repository
* Resolves #5 and #8 

### Helpful background context

The build/deploy workflows in our shared .github repository for Lambda functions and Fargate tasks have been cleaned up and consolidated. The mitlib-tf-workloads-ecr repository that generates the text for the three caller workflows has been updated and we just need to move those Terraform outputs into this repository to update the caller workflows.

### How can a reviewer manually see the effects of these changes?

Opening this PR triggered the dev build/deploy automation with the new caller workflow. It is also possible for the developer to manually trigger the dev-build workflow from this feature branch via the Actions tab.

### Includes new or updated dependencies?

NO

### Developer

- [N/A] All new ENV is documented in README
- [N/A] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer

- [ ] The commit message is clear and follows our guidelines (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes
